### PR TITLE
对xml文件解析的调整，合并raptorz对Python3支持部分

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.pyc
 *.db
 .idea
+*.swp

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# 变更说明
+
+作者：[@raptorz](https://github.com/raptorz)
+
+* 支持python3
+* 符合PEP8
+* 增加token管理，包括js_ticket
+* 增加模板消息发送功能
+* 可选是否验证https证书（原版为不验证）
+* event_map改为可扩展
+
 # 微信公众号Python-SDK
 
 作者: [@jeff_kit](http://twitter.com/jeff_kit)
@@ -193,7 +204,7 @@ on_xxx函数需要返回一个WxResponse的子类实例。WxResponse的子类及
 	from flask import Flask
 	app = Flask(__name__)
 	
-	@app.route('/wechat')
+	@app.route('/wechat', methods=['GET', 'POST'])
 	def wechat():
 		app = WxApp()
 		return app.process(request.args, request.data)

--- a/demo/demo/urls.py
+++ b/demo/demo/urls.py
@@ -4,7 +4,12 @@ from django.conf.urls import patterns, include, url
 # from django.contrib import admin
 # admin.autodiscover()
 
+
 urlpatterns = patterns('',
     url(r'^wechat/', 'echo.views.wechat'),
     url(r'^auth_event/', 'echo.views.auth_event'),
+    url(r'^component_access_token/$', 'echo.views.component_access_token_api'),
+    url(r'^pre_auth_code/$', 'echo.views.pre_auth_code_api'),
+    url(r'^authorize/$', 'echo.views.authorize'),
+    url(r'^save_authorization_info/$', 'echo.views.save_authorization_info', name='save_authorization_info'),
 )

--- a/demo/demo/urls.py
+++ b/demo/demo/urls.py
@@ -6,4 +6,5 @@ from django.conf.urls import patterns, include, url
 
 urlpatterns = patterns('',
     url(r'^wechat/', 'echo.views.wechat'),
+    url(r'^auth_event/', 'echo.views.auth_event'),
 )

--- a/demo/echo/views.py
+++ b/demo/echo/views.py
@@ -1,9 +1,16 @@
 # -*- coding: UTF-8 –*-
 # Create your views here.
+import json
+
+from django.core.cache import cache
+from django.core.urlresolvers import reverse
 from django.http import HttpResponse
-from wechat.component import WxComponentApplication
-from wechat.official import WxApplication, WxTextResponse
+
 from django.views.decorators.csrf import csrf_exempt
+
+from wechat.component import WxComponentApplication, WxComponentApi
+from wechat.official import WxApplication, WxTextResponse
+
 
 class WxApp(WxApplication):
     """把用户输入的文本原样返回。
@@ -16,6 +23,7 @@ class WxApp(WxApplication):
     def on_text(self, req):
         return WxTextResponse(req.Content, req)
 
+
 @csrf_exempt
 def wechat(request):
     app = WxApp()
@@ -24,14 +32,14 @@ def wechat(request):
 
 
 class WxComponentApp(WxComponentApplication):
-
     SECRET_TOKEN = ''
     APP_ID = ''
     ENCODING_AES_KEY = ''
 
     def on_verify_ticket(self, event):
         verify_ticket = event.get('ComponentVerifyTicket')
-        print "接收到的verify_ticket: %s", verify_ticket
+        print("接收到的verify_ticket: %s", verify_ticket)
+        cache.set('verify_ticket', verify_ticket)
 
 
 @csrf_exempt
@@ -39,3 +47,89 @@ def auth_event(request):
     app = WxComponentApp()
     rsp = app.process(request.GET, request.body)
     return HttpResponse(rsp)
+
+
+class WxComApi(WxComponentApi):
+    COMPONENT_APP_ID = ''
+    COMPONENT_APP_SECRET = ''
+
+
+def component_access_token_api(request):
+    verify_ticket = cache.get('verify_ticket')
+    if not verify_ticket:
+        verify_ticket = "verify_ticket为空, 请先获取verify_ticket"
+
+    api = WxComApi()
+    content, error = api.get_component_access_token(verify_ticket)
+    if content:
+        access_token = content.get('component_access_token')
+        cache.set('component_access_token', access_token)
+        content = json.dumps(content)
+    print('component_access_token: %s', content)
+    if error:
+        print('获取component_access_token失败: %s, %s', error.code, error.message)
+    return HttpResponse(content)
+
+
+def pre_auth_code_api(request):
+    access_token = cache.get('component_access_token')
+    if not access_token:
+        return HttpResponse("component_access_token为空, 请先获取component_access_token")
+
+    api = WxComApi()
+    content, error = api.get_pre_auth_code(access_token)
+    if content:
+        pre_auth_code = content.get('pre_auth_code')
+        cache.set('pre_auth_code', pre_auth_code)
+        content = json.dumps(content)
+    print('pre_auth_code: %s', content)
+    if error:
+        print('获取pre_auth_code失败: %s, %s', error.code, error.message)
+    return HttpResponse(content)
+
+
+def authorize(request):
+    """
+    授权演示页面
+    """
+    pre_auth_code = cache.get('pre_auth_code')
+    if not pre_auth_code:
+        return HttpResponse("pre_auth_code为空, 请先获取pre_auth_code")
+
+    html = """
+        <html>
+            <head>
+                <title>公众号第三方平台授权</title>
+            </head>
+            <body>
+                <a href='%s'>微信授权</a>
+            </body>
+        </html>
+        """
+
+    redirect_url = "http://%s%s" % (request.get_host(), reverse('save_authorization_info'))
+    api = WxComApi()
+    authorization_age = api.get_authorization_page(pre_auth_code, redirect_url)
+    html = html % (authorization_age)
+    return HttpResponse(html)
+
+
+def save_authorization_info(request):
+    """
+    用户授权成功
+    """
+    access_token = cache.get('component_access_token')
+    if not access_token:
+        return HttpResponse("component_access_token为空, 请先获取component_access_token")
+
+    print("request.GET: %r", request.GET)
+    auth_code = request.GET.get("auth_code", None)
+
+    api = WxComApi()
+    content, error = api.get_authorization_info(auth_code, access_token)
+    if content:
+        content = json.dumps(content)
+    print('authorization_info: %s', content)
+    if error:
+        print('获取授权信息失败: %s, %s', error.code, error.message)
+    return HttpResponse(content)

--- a/demo/echo/views.py
+++ b/demo/echo/views.py
@@ -1,6 +1,7 @@
 # -*- coding: UTF-8 –*-
 # Create your views here.
 from django.http import HttpResponse
+from wechat.component import WxComponentApplication
 from wechat.official import WxApplication, WxTextResponse
 from django.views.decorators.csrf import csrf_exempt
 
@@ -20,3 +21,21 @@ def wechat(request):
     app = WxApp()
     result = app.process(request.GET, request.body)
     return HttpResponse(result)
+
+
+class WxComponentApp(WxComponentApplication):
+
+    SECRET_TOKEN = ''
+    APP_ID = ''
+    ENCODING_AES_KEY = ''
+
+    def on_verify_ticket(self, event):
+        verify_ticket = event.get('ComponentVerifyTicket')
+        print "接收到的verify_ticket: %s", verify_ticket
+
+
+@csrf_exempt
+def auth_event(request):
+    app = WxComponentApp()
+    rsp = app.process(request.GET, request.body)
+    return HttpResponse(rsp)

--- a/wechat/__init__.py
+++ b/wechat/__init__.py
@@ -1,2 +1,2 @@
 #encoding=utf-8
-VERSION = "0.4.14"
+VERSION = "0.4.16"

--- a/wechat/component.py
+++ b/wechat/component.py
@@ -1,15 +1,15 @@
 # coding=utf-8
 import json
-import requests
-
-import xmltodict
 from hashlib import sha1
+
+import requests
+import xmltodict
+
 from .crypt import WXBizMsgCrypt
 from .models import APIError
 
 
 class WxComponentApplication(object):
-
     SECRET_TOKEN = None
     APP_ID = None
     ENCODING_AES_KEY = None
@@ -22,7 +22,7 @@ class WxComponentApplication(object):
 
         sign_ele = [self.token, timestamp, nonce]
         sign_ele.sort()
-        if(signature == sha1(''.join(sign_ele)).hexdigest()):
+        if (signature == sha1(''.join(sign_ele)).hexdigest()):
             return True, echostr
         else:
             return None
@@ -124,7 +124,6 @@ class WxComponentApplication(object):
 
 
 class WxComponentApi(object):
-
     """
     微信公众号第三方平台API
     """
@@ -162,6 +161,9 @@ class WxComponentApi(object):
         return self._process_response(rsp)
 
     def get_component_access_token(self, verify_ticket):
+        """
+        获取第三方平台component_access_token
+        """
         parameters = {
             "component_appid": self.component_appid,
             "component_appsecret": self.component_appsecret,
@@ -173,8 +175,6 @@ class WxComponentApi(object):
     def get_pre_auth_code(self, component_access_token):
         """
         获取预授权码
-        :param component_access_token: 第三方平台令牌
-        :return: 预授权码
         """
         pre_auth_code_url = "component/api_create_preauthcode?component_access_token=%s" % component_access_token
         parameters = {
@@ -186,8 +186,19 @@ class WxComponentApi(object):
     def get_authorization_page(self, pre_auth_code, redirect_uri):
         """
         获取第三方平台授权页地址
-        :return: 第三方平台授权页地址
         """
         authorization_page = "https://mp.weixin.qq.com/cgi-bin/componentloginpage?component_appid=%s&pre_auth_code=%s&redirect_uri=%s" % \
                              (self.component_appid, pre_auth_code, redirect_uri)
         return authorization_page
+
+    def get_authorization_info(self, auth_code, component_access_token):
+        """
+        获取授权公众号的授权信息
+        """
+        url = "component/api_query_auth?component_access_token=%s" % component_access_token
+        parameters = {
+            "component_appid": self.component_appid,
+            "authorization_code": auth_code
+        }
+        rsp = self._post(url, parameters)
+        return rsp

--- a/wechat/component.py
+++ b/wechat/component.py
@@ -182,3 +182,12 @@ class WxComponentApi(object):
         }
         rsp = self._post(pre_auth_code_url, parameters)
         return rsp
+
+    def get_authorization_page(self, pre_auth_code, redirect_uri):
+        """
+        获取第三方平台授权页地址
+        :return: 第三方平台授权页地址
+        """
+        authorization_page = "https://mp.weixin.qq.com/cgi-bin/componentloginpage?component_appid=%s&pre_auth_code=%s&redirect_uri=%s" % \
+                             (self.component_appid, pre_auth_code, redirect_uri)
+        return authorization_page

--- a/wechat/component.py
+++ b/wechat/component.py
@@ -1,0 +1,120 @@
+# coding=utf-8
+
+import xmltodict
+from hashlib import sha1
+from .crypt import WXBizMsgCrypt
+
+
+class WxComponentApplication(object):
+
+    SECRET_TOKEN = None
+    APP_ID = None
+    ENCODING_AES_KEY = None
+
+    def is_valid_params(self, params):
+        timestamp = params.get('timestamp', '')
+        nonce = params.get('nonce', '')
+        signature = params.get('signature', '')
+        echostr = params.get('echostr', '')
+
+        sign_ele = [self.token, timestamp, nonce]
+        sign_ele.sort()
+        if(signature == sha1(''.join(sign_ele)).hexdigest()):
+            return True, echostr
+        else:
+            return None
+
+    def process(self, params, xml=None, token=None, app_id=None, aes_key=None):
+        self.token = token if token else self.SECRET_TOKEN
+        self.app_id = app_id if app_id else self.APP_ID
+        self.aes_key = aes_key if aes_key else self.ENCODING_AES_KEY
+        assert self.token is not None
+
+        ret = self.is_valid_params(params)
+
+        if not ret:
+            return 'invalid request'
+        if not xml:
+            # 微信开发者设置的调用测试
+            return ret[1]
+
+        # 解密消息
+        encrypt_type = params.get('encrypt_type', '')
+        if encrypt_type != '' and encrypt_type != 'raw':
+            msg_signature = params.get('msg_signature', '')
+            timestamp = params.get('timestamp', '')
+            nonce = params.get('nonce', '')
+            if encrypt_type == 'aes':
+                cpt = WXBizMsgCrypt(self.token, self.aes_key, self.app_id)
+                err, xml = cpt.DecryptMsg(xml, msg_signature, timestamp, nonce)
+                if err:
+                    return 'decrypt message error, code : %s' % err
+            else:
+                return 'unsupport encrypty type %s' % encrypt_type
+
+        event = xmltodict.parse(xml)['xml']
+        info_type = event.get('InfoType')
+
+        func = self.handler_map().get(info_type, None)
+        if not func:
+            return "success"
+
+        func(event)
+
+        return "success"
+
+    def handler_map(self):
+        if getattr(self, 'handlers', None):
+            return self.handlers
+        return {
+            'component_verify_ticket': self.on_verify_ticket,
+            'unauthorized': self.on_unauthorized,
+            'authorized': self.on_authorized,
+            'updateauthorized': self.on_updateauthorized,
+        }
+
+    def on_verify_ticket(self, event):
+        """
+        字段名称	                  字段描述
+        AppId	                  第三方平台appid
+        CreateTime	              时间戳
+        InfoType	              component_verify_ticket
+        ComponentVerifyTicket	  Ticket内容
+        """
+        pass
+
+    def on_unauthorized(self, event):
+        """
+        字段名称	                        字段描述
+        AppId	                        第三方平台appid
+        CreateTime	                    时间戳
+        InfoType	                    unauthorized是取消授权
+        AuthorizerAppid	                公众号
+        AuthorizationCode	            授权码，可用于换取公众号的接口调用凭据
+        AuthorizationCodeExpiredTime	授权码过期时间
+        """
+        pass
+
+    def on_authorized(self, event):
+        """
+        字段名称	                        字段描述
+        AppId	                        第三方平台appid
+        CreateTime	                    时间戳
+        InfoType	                    authorized是授权成功
+        AuthorizerAppid	                公众号
+        AuthorizationCode	            授权码，可用于换取公众号的接口调用凭据
+        AuthorizationCodeExpiredTime	授权码过期时间
+        """
+        pass
+
+    def on_updateauthorized(self, event):
+        """
+        字段名称	                        字段描述
+        AppId	                        第三方平台appid
+        CreateTime	                    时间戳
+        InfoType	                    updateauthorized是更新授权
+        AuthorizerAppid	                公众号
+        AuthorizationCode	            授权码，可用于换取公众号的接口调用凭据
+        AuthorizationCodeExpiredTime	授权码过期时间
+        """
+        pass

--- a/wechat/component.py
+++ b/wechat/component.py
@@ -169,3 +169,16 @@ class WxComponentApi(object):
         }
         rsp = self._post("component/api_component_token", parameters)
         return rsp
+
+    def get_pre_auth_code(self, component_access_token):
+        """
+        获取预授权码
+        :param component_access_token: 第三方平台令牌
+        :return: 预授权码
+        """
+        pre_auth_code_url = "component/api_create_preauthcode?component_access_token=%s" % component_access_token
+        parameters = {
+            'component_appid': self.component_appid
+        }
+        rsp = self._post(pre_auth_code_url, parameters)
+        return rsp

--- a/wechat/models.py
+++ b/wechat/models.py
@@ -48,19 +48,17 @@ class WxRequest(object):
         #         self.__dict__.update({param.tagName: text.data})
         #     else:
         #         self.__dict__.update({param.tagName: ''})
-        doc = xmltodict.parse(xml)
-        params = doc.get('xml', None)
-        if not None:
+        doc = xmltodict.parse(xml).get('xml',None)
+        self._params(doc)
+
+    def _params(self, params):
+        if params is None:
+            pass
+        else:
             for param in params:
                 text = params[param]
                 if isinstance(text, dict):
-                    for k in text:
-                        v = text[k]
-                        if isinstance(v, dict):
-                            # 可以修改成一个递归，以便解析更多层
-                            pass
-                        else:
-                            self.__dict__.update({k: v})
+                    self._params(text)
                 else:
                     self.__dict__.update({param: text})
 

--- a/wechat/models.py
+++ b/wechat/models.py
@@ -166,7 +166,7 @@ class WxNewsResponse(WxResponse):
 
     def __init__(self, articles, request):
         super(WxNewsResponse, self).__init__(request)
-        if isinstance(articles, list) or isinstance(articles, tuple):
+        if isinstance(articles, list):
             self.articles = articles
         else:
             self.articles = [articles]

--- a/wechat/models.py
+++ b/wechat/models.py
@@ -1,8 +1,13 @@
-#encoding=utf-8
+# encoding=utf-8
 
 from xml.dom import minidom
 import collections
 import time
+import sys
+
+if sys.version > "3":
+    long = int
+    unicode = str
 
 
 def kv2element(key, value, doc):

--- a/wechat/models.py
+++ b/wechat/models.py
@@ -1,6 +1,7 @@
 # encoding=utf-8
 
 from xml.dom import minidom
+import xmltodict
 import collections
 import time
 import sys
@@ -38,15 +39,30 @@ class WxRequest(object):
     def __init__(self, xml=None):
         if not xml:
             return
-        doc = minidom.parseString(xml)
-        params = [ele for ele in doc.childNodes[0].childNodes
-                  if isinstance(ele, minidom.Element)]
-        for param in params:
-            if param.childNodes:
-                text = param.childNodes[0]
-                self.__dict__.update({param.tagName: text.data})
-            else:
-                self.__dict__.update({param.tagName: ''})
+        # doc = minidom.parseString(xml)
+        # params = [ele for ele in doc.childNodes[0].childNodes
+        #           if isinstance(ele, minidom.Element)]
+        # for param in params:
+        #     if param.childNodes:
+        #         text = param.childNodes[0]
+        #         self.__dict__.update({param.tagName: text.data})
+        #     else:
+        #         self.__dict__.update({param.tagName: ''})
+        doc = xmltodict.parse(xml)
+        params = doc.get('xml', None)
+        if not None:
+            for param in params:
+                text = params[param]
+                if isinstance(text, dict):
+                    for k in text:
+                        v = text[k]
+                        if isinstance(v, dict):
+                            # 可以修改成一个递归，以便解析更多层
+                            pass
+                        else:
+                            self.__dict__.update({k: v})
+                else:
+                    self.__dict__.update({param: text})
 
 
 class WxResponse(object):

--- a/wechat/token_manager.py
+++ b/wechat/token_manager.py
@@ -1,0 +1,82 @@
+# encoding=utf-8
+
+from time import time, sleep
+
+import redis
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class TokenManager(object):
+    def get_token(self, fn_get_access_token):
+        token = self.token
+        expires = self.expires
+        if not token and not expires:
+            for i in xrang(12):
+                sleep(5)
+                if self.token:
+                    break
+        elif not token or expires and expires < time():
+            self.expires = None
+            self.refresh_token(fn_get_access_token)
+        return self.token
+
+    def refresh_token(self, fn_get_access_token):
+        token, err = fn_get_access_token()
+        if token and not err:
+            self.token = token['access_token']
+            self.expires = time() + token['expires_in']
+        else:
+            self.token = None
+
+
+class LocalTokenManager(TokenManager):
+    def __init__(self):
+        self._access_token = None
+        self._expires = time()
+
+    @property
+    def token(self):
+        return self._access_token
+
+    @token.setter
+    def token(self, token):
+        self._access_token = token
+
+    @property
+    def expires(self):
+        return self._expires
+
+    @expires.setter
+    def expires(self, expires):
+        self._expires = expires
+
+
+class RedisTokenManager(TokenManager):
+    def __init__(self, postfix="", **kwargs):
+        self.token_name = "_".join(["access_token", postfix])
+        self.expires_name = "_".join(["access_token_expires", postfix])
+        self.redis = redis.Redis(**kwargs)
+        if not self.expires:
+            self.expires = time()
+
+    @property
+    def token(self):
+        token = self.redis.get(self.token_name)
+        return str(token, "utf-8") if token and isinstance(
+            token, bytes) else token
+
+    @token.setter
+    def token(self, token):
+        self.redis.set(self.token_name, token)
+
+    @property
+    def expires(self):
+        expires = self.redis.get(self.expires_name)
+        return expires
+
+    @expires.setter
+    def expires(self, expires):
+        self.redis.set(self.expires_name, expires)


### PR DESCRIPTION
* 合并raptorz对Python3支持的部分
* 修改readme中Flask的示例代码
* 使用xmltodict解析xml
* 增加字典遍历方法
* 修复发布单个图文信息时content_nodes会直接遍历图文信息元组内的元素，导致fields2elements解析错误。