### PR TITLE
发布单个图文信息时fields2elements解析出错

### DIFF
--- a/wechat/models.py
+++ b/wechat/models.py
@@ -6,6 +6,8 @@ import time
 
 
 def kv2element(key, value, doc):
+    if value is None:
+        return None
     ele = doc.createElement(key)
     if isinstance(value, str) or isinstance(value, unicode):
         data = doc.createCDATASection(value)
@@ -21,7 +23,8 @@ def fields2elements(tupleObj, enclose_tag=None, doc=None):
         xml = doc.createElement(enclose_tag)
         for key in tupleObj._fields:
             ele = kv2element(key, getattr(tupleObj, key), doc)
-            xml.appendChild(ele)
+            if ele is not None:
+                xml.appendChild(ele)
         return xml
     else:
         return [kv2element(key, getattr(tupleObj, key), doc)

--- a/wechat/models.py
+++ b/wechat/models.py
@@ -147,7 +147,7 @@ class WxNewsResponse(WxResponse):
 
     def __init__(self, articles, request):
         super(WxNewsResponse, self).__init__(request)
-        if isinstance(articles, list) or isinstance(articles, tuple):
+        if isinstance(articles, list):
             self.articles = articles
         else:
             self.articles = [articles]


### PR DESCRIPTION
发布单个图文信息时content_nodes会直接遍历图文信息元组内的元素，导致fields2elements解析错误。
